### PR TITLE
Improve partial db updater

### DIFF
--- a/partial_db_updater.py
+++ b/partial_db_updater.py
@@ -40,7 +40,7 @@ def get_fixture_update_lots(
 
 
 def get_all_fixtures_ids_to_update() -> List["DBFixture"]:
-    todays_fixtures = FIXTURES_DB_MANAGER.get_games_in_surrounding_n_days(0)
+    todays_fixtures = FIXTURES_DB_MANAGER.get_games_in_surrounding_n_hours(2)
 
     return [fixture.id for fixture in todays_fixtures if fixture]
 

--- a/src/utils/date_utils.py
+++ b/src/utils/date_utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from enum import Enum
+from time import time
 
 import pytz
 
@@ -41,3 +42,10 @@ def get_date_spanish_text_format(date: datetime) -> str:
 
 def get_formatted_date(date: str) -> datetime:
     return datetime.strptime(date[:-6], "%Y-%m-%dT%H:%M:%S")
+
+
+def is_time_between(check_time: time, begin_time: time, end_time: time):
+    if begin_time < end_time:
+        return check_time >= begin_time and check_time <= end_time
+    else:
+        return check_time >= begin_time or check_time <= end_time

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from src.utils.date_utils import get_formatted_date, is_time_between
+
+
+def test_get_formatted_date():
+    # given
+    date = "2021-03-09T00:30:00+00:00"
+
+    # when
+    formatted_date = get_formatted_date(date)
+
+    # then
+    assert type(formatted_date) is datetime
+    assert str(formatted_date) == "2021-03-09 00:30:00"
+
+
+def test_is_time_between():
+    with freeze_time("2021-09-29 18:30:00"):
+        # given
+        begin_time = datetime.strptime(
+            "2021-09-29 16:30:00", "%Y-%m-%d %H:%M:%S"
+        ).time()
+        end_time = datetime.strptime("2021-09-29 19:30:00", "%Y-%m-%d %H:%M:%S").time()
+
+        # when - then
+        assert is_time_between(datetime.utcnow().time(), begin_time, end_time) is True
+
+
+def test_is_time_between_false():
+    with freeze_time("2021-09-29 18:30:00"):
+        # given
+        begin_time = datetime.strptime(
+            "2021-09-29 20:30:00", "%Y-%m-%d %H:%M:%S"
+        ).time()
+        end_time = datetime.strptime("2021-09-29 21:30:00", "%Y-%m-%d %H:%M:%S").time()
+
+        # when - then
+        assert is_time_between(datetime.utcnow().time(), begin_time, end_time) is False


### PR DESCRIPTION
Changing the way we retrieve the fixtures to update every time. During weekends there are too many matches, and taking all the day's fixtures end up in too many of them and consenquently too many requests performed to the API.